### PR TITLE
Improved readability when setting flag

### DIFF
--- a/src/main/java/org/cubedb/offheap/OffHeapPartition.java
+++ b/src/main/java/org/cubedb/offheap/OffHeapPartition.java
@@ -415,11 +415,14 @@ public class OffHeapPartition implements Partition {
        */
       for (int matcherId = 0; matcherId < matchersArray.length; matcherId++) {
         IdMatcher matcher = matchersArray[matcherId];
-        columnMatches[matcherId] = true;
         final int valueId = columns[matcherId].get(i);
         columnValues[matcherId] = valueId;
+
         if (matcher != null) {
           columnMatches[matcherId] = matcher.match(valueId);
+        } else {
+          // If no matcher is set for this column we consider it matched
+          columnMatches[matcherId] = true;
         }
       }
 


### PR DESCRIPTION
Out of the box it's not described why the default value for the column's match is `true` by default , this change make it more explicit