### PR TITLE
Reduced log level during tests

### DIFF
--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,8 @@
+# don't limit by the logging level, and use two appenders.
+log4j.rootCategory=,TTY
+
+# TTY is set to be a ConsoleAppender using a PatternLayout.
+log4j.appender.TTY=org.apache.log4j.ConsoleAppender
+log4j.appender.TTY.Threshold=INFO
+log4j.appender.TTY.layout=org.apache.log4j.PatternLayout
+log4j.appender.TTY.layout.ConversionPattern=[%t] %d{yyyy-MM-dd HH:mm:ss.SSS} %-5p [%-28c{2}] - %m%n


### PR DESCRIPTION
Reduces the output to `INFO` level during unit tests so the build don't fail on Travis because the output is bigger then 4Mb